### PR TITLE
feat: allow publish/resolve using only local datastore

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "release": "npm run docs:no-publish && aegir run release && npm run docs"
   },
   "devDependencies": {
-    "aegir": "^38.1.0"
+    "aegir": "^38.1.0",
+    "sinon-ts": "^1.0.0"
   },
   "type": "module",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "release": "npm run docs:no-publish && aegir run release && npm run docs"
   },
   "devDependencies": {
-    "aegir": "^38.1.0",
-    "sinon-ts": "^1.0.0"
+    "aegir": "^38.1.0"
   },
   "type": "module",
   "workspaces": [

--- a/packages/ipns/package.json
+++ b/packages/ipns/package.json
@@ -179,7 +179,8 @@
     "@libp2p/peer-id-factory": "^2.0.1",
     "aegir": "^38.1.0",
     "datastore-core": "^9.0.3",
-    "sinon": "^15.0.1"
+    "sinon": "^15.0.1",
+    "sinon-ts": "^1.0.0"
   },
   "browser": {
     "./dist/src/utils/resolve-dns-link.js": "./dist/src/utils/resolve-dns-link.browser.js"

--- a/packages/ipns/test/resolve.spec.ts
+++ b/packages/ipns/test/resolve.spec.ts
@@ -2,21 +2,25 @@
 
 import { expect } from 'aegir/chai'
 import { MemoryDatastore } from 'datastore-core'
-import type { IPNS } from '../src/index.js'
+import type { IPNS, IPNSRouting } from '../src/index.js'
 import { ipns } from '../src/index.js'
 import { CID } from 'multiformats/cid'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import Sinon from 'sinon'
+import { StubbedInstance, stubInterface } from 'sinon-ts'
 
 const cid = CID.parse('QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn')
 
 describe('resolve', () => {
   let name: IPNS
+  let routing: StubbedInstance<IPNSRouting>
 
-  before(async () => {
+  beforeEach(async () => {
     const datastore = new MemoryDatastore()
+    routing = stubInterface<IPNSRouting>()
+    routing.get.throws(new Error('Not found'))
 
-    name = ipns({ datastore })
+    name = ipns({ datastore }, [routing])
   })
 
   it('should resolve a record', async () => {
@@ -24,6 +28,25 @@ describe('resolve', () => {
     await name.publish(key, cid)
 
     const resolvedValue = await name.resolve(key)
+
+    if (resolvedValue == null) {
+      throw new Error('Did not resolve entry')
+    }
+
+    expect(resolvedValue.toString()).to.equal(cid.toString())
+  })
+
+  it('should resolve a record offline', async () => {
+    const key = await createEd25519PeerId()
+    await name.publish(key, cid)
+
+    expect(routing.put.called).to.be.true()
+
+    const resolvedValue = await name.resolve(key, {
+      offline: true
+    })
+
+    expect(routing.get.called).to.be.false()
 
     if (resolvedValue == null) {
       throw new Error('Did not resolve entry')


### PR DESCRIPTION
Adds an `offline` option to publish and resolve that causes this module to only use the local datastore instead of any configured routers.