### PR TITLE
feat!: update helia to v3 and multiformats to v13

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: daily
     time: "10:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 20
   commit-message:
     prefix: "deps"
     prefix-development: "deps(dev)"

--- a/.github/workflows/js-test-and-release.yml
+++ b/.github/workflows/js-test-and-release.yml
@@ -9,7 +9,9 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   packages: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,0 +1,12 @@
+name: Semantic PR
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    uses: pl-strflt/.github/.github/workflows/reusable-semantic-pull-request.yml@v0.3

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,13 @@
+name: Close and mark stale issue
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    uses: pl-strflt/.github/.github/workflows/reusable-stale-issue.yml@v0.3

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,3 @@ node_modules
 package-lock.json
 yarn.lock
 .vscode
-.env
-.envrc
-.tool-versions

--- a/README.md
+++ b/README.md
@@ -13,30 +13,23 @@
 
 > An implementation of IPNS for Helia
 
-## Table of contents <!-- omit in toc -->
-
-- [Structure](#structure)
-- [API Docs](#api-docs)
-- [License](#license)
-- [Contribute](#contribute)
-
-## Structure
+# Packages
 
 - [`/packages/interop`](./packages/interop) Interop tests for @helia/ipns
 - [`/packages/ipns`](./packages/ipns) An implementation of IPNS for Helia
 
-## API Docs
+# API Docs
 
 - <https://ipfs.github.io/helia-ipns>
 
-## License
+# License
 
 Licensed under either of
 
 - Apache 2.0, ([LICENSE-APACHE](LICENSE-APACHE) / <http://www.apache.org/licenses/LICENSE-2.0>)
 - MIT ([LICENSE-MIT](LICENSE-MIT) / <http://opensource.org/licenses/MIT>)
 
-## Contribute
+# Contribute
 
 Contributions welcome! Please check out [the issues](https://github.com/ipfs/helia-ipns/issues).
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/ipfs/helia-ipns/issues"
   },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "keywords": [
     "ipfs"
   ],
@@ -36,7 +40,7 @@
     "docs:no-publish": "NODE_OPTIONS=--max_old_space_size=8192 aegir docs --publish false -- --exclude packages/interop"
   },
   "devDependencies": {
-    "aegir": "^41.1.14",
+    "aegir": "^42.0.1",
     "npm-run-all": "^4.1.5"
   },
   "type": "module",

--- a/packages/interop/README.md
+++ b/packages/interop/README.md
@@ -13,35 +13,14 @@
 
 > Interop tests for @helia/ipns
 
-## Table of contents <!-- omit in toc -->
-
-- [Install](#install)
-  - [Browser `<script>` tag](#browser-script-tag)
-- [License](#license)
-- [Contribute](#contribute)
-
-## Install
-
-```console
-$ npm i @helia/ipns-interop
-```
-
-### Browser `<script>` tag
-
-Loading this module through a script tag will make it's exports available as `HeliaIpnsInterop` in the global namespace.
-
-```html
-<script src="https://unpkg.com/@helia/ipns-interop/dist/index.min.js"></script>
-```
-
-## License
+# License
 
 Licensed under either of
 
 - Apache 2.0, ([LICENSE-APACHE](LICENSE-APACHE) / <http://www.apache.org/licenses/LICENSE-2.0>)
 - MIT ([LICENSE-MIT](LICENSE-MIT) / <http://opensource.org/licenses/MIT>)
 
-## Contribute
+# Contribute
 
 Contributions welcome! Please check out [the issues](https://github.com/ipfs/helia-ipns/issues).
 

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -3,13 +3,17 @@
   "version": "0.0.0",
   "description": "Interop tests for @helia/ipns",
   "license": "Apache-2.0 OR MIT",
-  "homepage": "https://github.com/ipfs/helia-ipns/tree/master/packages/interop#readme",
+  "homepage": "https://github.com/ipfs/helia-ipns/tree/main/packages/interop#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ipfs/helia-ipns.git"
   },
   "bugs": {
     "url": "https://github.com/ipfs/helia-ipns/issues"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   },
   "keywords": [
     "IPFS"
@@ -49,32 +53,34 @@
     "test:electron-main": "aegir test -t electron-main"
   },
   "devDependencies": {
-    "@chainsafe/libp2p-gossipsub": "^10.1.0",
-    "@chainsafe/libp2p-noise": "^13.0.0",
-    "@chainsafe/libp2p-yamux": "^5.0.0",
-    "@helia/interface": "^2.0.0",
+    "@chainsafe/libp2p-gossipsub": "^11.0.1",
+    "@chainsafe/libp2p-noise": "^14.1.0",
+    "@chainsafe/libp2p-yamux": "^6.0.1",
+    "@helia/interface": "^3.0.0",
     "@helia/ipns": "^3.0.0",
-    "@libp2p/interface": "^0.1.2",
-    "@libp2p/kad-dht": "^10.0.4",
-    "@libp2p/peer-id": "^3.0.2",
-    "@libp2p/peer-id-factory": "^3.0.3",
-    "@libp2p/tcp": "^8.0.4",
-    "@libp2p/websockets": "^7.0.4",
-    "aegir": "^41.1.14",
+    "@libp2p/identify": "^1.0.9",
+    "@libp2p/interface": "^1.1.1",
+    "@libp2p/kad-dht": "^12.0.2",
+    "@libp2p/keychain": "^4.0.5",
+    "@libp2p/peer-id": "^4.0.4",
+    "@libp2p/peer-id-factory": "^4.0.3",
+    "@libp2p/tcp": "^9.0.10",
+    "@libp2p/websockets": "^8.0.10",
+    "aegir": "^42.0.1",
     "blockstore-core": "^4.0.1",
     "datastore-core": "^9.0.3",
-    "helia": "^2.0.1",
+    "helia": "^3.0.0",
     "ipfsd-ctl": "^13.0.0",
-    "ipns": "^7.0.1",
+    "ipns": "^8.0.0",
     "it-all": "^3.0.2",
     "it-last": "^3.0.1",
     "it-map": "^3.0.3",
-    "kubo": "^0.24.0",
+    "kubo": "^0.25.0",
     "kubo-rpc-client": "^3.0.0",
-    "libp2p": "^0.46.6",
+    "libp2p": "^1.1.1",
     "merge-options": "^3.0.4",
-    "multiformats": "^12.0.1",
-    "uint8arrays": "^4.0.3",
+    "multiformats": "^13.0.0",
+    "uint8arrays": "^5.0.1",
     "wherearewe": "^2.0.1"
   },
   "browser": {

--- a/packages/interop/test/fixtures/create-helia.ts
+++ b/packages/interop/test/fixtures/create-helia.ts
@@ -6,10 +6,10 @@ import { MemoryDatastore } from 'datastore-core'
 import { createHelia } from 'helia'
 import { createLibp2p, type Libp2pOptions } from 'libp2p'
 import type { Helia } from '@helia/interface'
+import type { Identify } from '@libp2p/identify'
 import type { Libp2p } from '@libp2p/interface'
-import type { IdentifyService } from 'libp2p/identify'
 
-export async function createHeliaNode <T extends { identify: IdentifyService }> (config: Libp2pOptions<T> = {}): Promise<Helia<Libp2p<T>>> {
+export async function createHeliaNode <T extends { identify: Identify }> (config: Libp2pOptions<T> = {}): Promise<Helia<Libp2p<T>>> {
   const blockstore = new MemoryBlockstore()
   const datastore = new MemoryDatastore()
 

--- a/packages/interop/test/fixtures/create-peer-ids.ts
+++ b/packages/interop/test/fixtures/create-peer-ids.ts
@@ -3,7 +3,7 @@ import map from 'it-map'
 import { sha256 } from 'multiformats/hashes/sha2'
 import { compare as uint8ArrayCompare } from 'uint8arrays/compare'
 import { xor as uint8ArrayXor } from 'uint8arrays/xor'
-import type { PeerId } from '@libp2p/interface/peer-id'
+import type { PeerId } from '@libp2p/interface'
 
 /**
  * Sort peers by distance to the KadID of the passed buffer

--- a/packages/interop/test/fixtures/key-types.ts
+++ b/packages/interop/test/fixtures/key-types.ts
@@ -1,4 +1,4 @@
-import type { PeerIdType } from '@libp2p/interface/peer-id'
+import type { PeerIdType } from '@libp2p/interface'
 
 export const keyTypes: PeerIdType[] = [
   'Ed25519',

--- a/packages/ipns/README.md
+++ b/packages/ipns/README.md
@@ -17,27 +17,27 @@
 
 IPNS operations using a Helia node
 
-## Example
+## Example - Using libp2p and pubsub routers
 
 With IPNSRouting routers:
 
 ```typescript
 import { createHelia } from 'helia'
 import { ipns } from '@helia/ipns'
-import { dht, pubsub } from '@helia/ipns/routing'
+import { libp2p, pubsub } from '@helia/ipns/routing'
 import { unixfs } from '@helia/unixfs'
 
 const helia = await createHelia()
 const name = ipns(helia, {
  routers: [
-   dht(helia),
+   libp2p(helia),
    pubsub(helia)
  ]
 })
 
 // create a public key to publish as an IPNS name
-const keyInfo = await helia.libp2p.keychain.createKey('my-key')
-const peerId = await helia.libp2p.keychain.exportPeerId(keyInfo.name)
+const keyInfo = await helia.libp2p.services.keychain.createKey('my-key')
+const peerId = await helia.libp2p.services.keychain.exportPeerId(keyInfo.name)
 
 // store some data to publish
 const fs = unixfs(helia)
@@ -50,7 +50,7 @@ await name.publish(peerId, cid)
 const cid = name.resolve(peerId)
 ```
 
-## Example
+## Example - Using custom DNS over HTTPS resolvers
 
 With default DNSResolver resolvers:
 
@@ -70,7 +70,7 @@ const name = ipns(helia, {
 const cid = name.resolveDns('some-domain-with-dnslink-entry.com')
 ```
 
-## Example
+## Example - Resolving a domain with a dnslink entry
 
 Calling `resolveDns` with the `@helia/ipns` instance:
 
@@ -90,7 +90,7 @@ console.info(cid)
 // QmWebsite
 ```
 
-## Example
+## Example - Using DNS-Over-HTTPS
 
 This example uses the Mozilla provided RFC 1035 DNS over HTTPS service. This
 uses binary DNS records so requires extra dependencies to process the
@@ -109,7 +109,7 @@ const cid = name.resolveDns('ipfs.io', {
 })
 ```
 
-## Example
+## Example - Using DNS-JSON-Over-HTTPS
 
 DNS-JSON-Over-HTTPS resolvers use the RFC 8427 `application/dns-json` and can
 result in a smaller browser bundle due to the response being plain JSON.
@@ -124,3 +124,40 @@ const cid = name.resolveDns('ipfs.io', {
   ]
 })
 ```
+
+# Install
+
+```console
+$ npm i @helia/ipns
+```
+
+## Browser `<script>` tag
+
+Loading this module through a script tag will make it's exports available as `HeliaIpns` in the global namespace.
+
+```html
+<script src="https://unpkg.com/@helia/ipns/dist/index.min.js"></script>
+```
+
+# API Docs
+
+- <https://ipfs.github.io/helia-ipns/modules/_helia_ipns.html>
+
+# License
+
+Licensed under either of
+
+- Apache 2.0, ([LICENSE-APACHE](LICENSE-APACHE) / <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT ([LICENSE-MIT](LICENSE-MIT) / <http://opensource.org/licenses/MIT>)
+
+# Contribute
+
+Contributions welcome! Please check out [the issues](https://github.com/ipfs/helia-ipns/issues).
+
+Also see our [contributing document](https://github.com/ipfs/community/blob/master/CONTRIBUTING_JS.md) for more information on how we work, and about contributing in general.
+
+Please be aware that all interactions related to this repo are subject to the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+
+[![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md)

--- a/packages/ipns/package.json
+++ b/packages/ipns/package.json
@@ -3,13 +3,17 @@
   "version": "3.0.1",
   "description": "An implementation of IPNS for Helia",
   "license": "Apache-2.0 OR MIT",
-  "homepage": "https://github.com/ipfs/helia-ipns/tree/master/packages/ipns#readme",
+  "homepage": "https://github.com/ipfs/helia-ipns/tree/main/packages/ipns#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ipfs/helia-ipns.git"
   },
   "bugs": {
     "url": "https://github.com/ipfs/helia-ipns/issues"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   },
   "keywords": [
     "IPFS"
@@ -43,13 +47,13 @@
       "types": "./dist/src/index.d.ts",
       "import": "./dist/src/index.js"
     },
-    "./routing": {
-      "types": "./dist/src/routing/index.d.ts",
-      "import": "./dist/src/routing/index.js"
-    },
     "./dns-resolvers": {
       "types": "./dist/src/dns-resolvers/index.d.ts",
       "import": "./dist/src/dns-resolvers/index.js"
+    },
+    "./routing": {
+      "types": "./dist/src/routing/index.d.ts",
+      "import": "./dist/src/routing/index.js"
     }
   },
   "eslintConfig": {
@@ -159,28 +163,28 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/interface": "^0.1.4",
-    "@libp2p/kad-dht": "^10.0.11",
-    "@libp2p/logger": "^3.0.2",
-    "@libp2p/peer-id": "^3.0.2",
-    "dns-over-http-resolver": "^2.1.3",
+    "@libp2p/interface": "^1.1.1",
+    "@libp2p/kad-dht": "^12.0.2",
+    "@libp2p/logger": "^4.0.4",
+    "@libp2p/peer-id": "^4.0.4",
+    "dns-over-http-resolver": "^3.0.0",
     "dns-packet": "^5.6.0",
     "hashlru": "^2.3.0",
     "interface-datastore": "^8.0.0",
-    "ipns": "^7.0.1",
+    "ipns": "^8.0.0",
     "is-ipfs": "^8.0.1",
-    "multiformats": "^12.0.1",
-    "p-queue": "^7.3.0",
+    "multiformats": "^13.0.0",
+    "p-queue": "^8.0.1",
     "progress-events": "^1.0.0",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^5.0.1"
   },
   "devDependencies": {
-    "@libp2p/peer-id-factory": "^3.0.3",
+    "@libp2p/peer-id-factory": "^4.0.3",
     "@types/dns-packet": "^5.6.4",
-    "aegir": "^41.1.14",
+    "aegir": "^42.0.1",
     "datastore-core": "^9.0.3",
     "sinon": "^17.0.0",
-    "sinon-ts": "^1.0.0"
+    "sinon-ts": "^2.0.0"
   },
   "browser": {
     "./dist/src/dns-resolvers/resolver.js": "./dist/src/dns-resolvers/resolver.browser.js"

--- a/packages/ipns/src/index.ts
+++ b/packages/ipns/src/index.ts
@@ -3,27 +3,27 @@
  *
  * IPNS operations using a Helia node
  *
- * @example
+ * @example Using libp2p and pubsub routers
  *
  * With {@link IPNSRouting} routers:
  *
  * ```typescript
  * import { createHelia } from 'helia'
  * import { ipns } from '@helia/ipns'
- * import { dht, pubsub } from '@helia/ipns/routing'
+ * import { libp2p, pubsub } from '@helia/ipns/routing'
  * import { unixfs } from '@helia/unixfs'
  *
  * const helia = await createHelia()
  * const name = ipns(helia, {
  *  routers: [
- *    dht(helia),
+ *    libp2p(helia),
  *    pubsub(helia)
  *  ]
  * })
  *
  * // create a public key to publish as an IPNS name
- * const keyInfo = await helia.libp2p.keychain.createKey('my-key')
- * const peerId = await helia.libp2p.keychain.exportPeerId(keyInfo.name)
+ * const keyInfo = await helia.libp2p.services.keychain.createKey('my-key')
+ * const peerId = await helia.libp2p.services.keychain.exportPeerId(keyInfo.name)
  *
  * // store some data to publish
  * const fs = unixfs(helia)
@@ -36,7 +36,7 @@
  * const cid = name.resolve(peerId)
  * ```
  *
- * @example
+ * @example Using custom DNS over HTTPS resolvers
  *
  * With default {@link DNSResolver} resolvers:
  *
@@ -56,7 +56,7 @@
  * const cid = name.resolveDns('some-domain-with-dnslink-entry.com')
  * ```
  *
- * @example
+ * @example Resolving a domain with a dnslink entry
  *
  * Calling `resolveDns` with the `@helia/ipns` instance:
  *
@@ -76,7 +76,7 @@
  * // QmWebsite
  * ```
  *
- * @example
+ * @example Using DNS-Over-HTTPS
  *
  * This example uses the Mozilla provided RFC 1035 DNS over HTTPS service. This
  * uses binary DNS records so requires extra dependencies to process the
@@ -95,7 +95,7 @@
  * })
  * ```
  *
- * @example
+ * @example Using DNS-JSON-Over-HTTPS
  *
  * DNS-JSON-Over-HTTPS resolvers use the RFC 8427 `application/dns-json` and can
  * result in a smaller browser bundle due to the response being plain JSON.
@@ -112,7 +112,7 @@
  * ```
  */
 
-import { CodeError } from '@libp2p/interface/errors'
+import { CodeError } from '@libp2p/interface'
 import { logger } from '@libp2p/logger'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { create, marshal, peerIdToRoutingKey, unmarshal } from 'ipns'
@@ -124,8 +124,7 @@ import { defaultResolver } from './dns-resolvers/default.js'
 import { localStore, type LocalStore } from './routing/local-store.js'
 import type { IPNSRouting, IPNSRoutingEvents } from './routing/index.js'
 import type { DNSResponse } from './utils/dns.js'
-import type { AbortOptions } from '@libp2p/interface'
-import type { PeerId } from '@libp2p/interface/peer-id'
+import type { AbortOptions, PeerId } from '@libp2p/interface'
 import type { Datastore } from 'interface-datastore'
 import type { IPNSRecord } from 'ipns'
 import type { ProgressEvent, ProgressOptions } from 'progress-events'

--- a/packages/ipns/src/routing/index.ts
+++ b/packages/ipns/src/routing/index.ts
@@ -1,4 +1,4 @@
-import type { DHTProgressEvents } from './dht.js'
+import type { Libp2pContentRoutingProgressEvents } from './libp2p.js'
 import type { DatastoreProgressEvents } from './local-store.js'
 import type { PubSubProgressEvents } from './pubsub.js'
 import type { AbortOptions } from '@libp2p/interface'
@@ -19,8 +19,8 @@ export interface IPNSRouting {
 
 export type IPNSRoutingEvents =
   DatastoreProgressEvents |
-  DHTProgressEvents |
+  Libp2pContentRoutingProgressEvents |
   PubSubProgressEvents
 
-export { dht } from './dht.js'
+export { libp2p } from './libp2p.js'
 export { pubsub } from './pubsub.js'

--- a/packages/ipns/src/routing/libp2p.ts
+++ b/packages/ipns/src/routing/libp2p.ts
@@ -1,21 +1,21 @@
 import { CustomProgressEvent, type ProgressEvent } from 'progress-events'
 import type { GetOptions, PutOptions } from './index.js'
 import type { IPNSRouting } from '../index.js'
-import type { ContentRouting } from '@libp2p/interface/content-routing'
+import type { ContentRouting } from '@libp2p/interface'
 
-export interface DHTRoutingComponents {
+export interface Libp2pContentRoutingComponents {
   libp2p: {
     contentRouting: ContentRouting
   }
 }
 
-export type DHTProgressEvents =
-  ProgressEvent<'ipns:routing:dht:error', Error>
+export type Libp2pContentRoutingProgressEvents =
+  ProgressEvent<'ipns:routing:libp2p:error', Error>
 
-export class DHTRouting implements IPNSRouting {
+export class Libp2pContentRouting implements IPNSRouting {
   private readonly contentRouting: ContentRouting
 
-  constructor (components: DHTRoutingComponents) {
+  constructor (components: Libp2pContentRoutingComponents) {
     this.contentRouting = components.libp2p.contentRouting
   }
 
@@ -23,7 +23,7 @@ export class DHTRouting implements IPNSRouting {
     try {
       await this.contentRouting.put(routingKey, marshaledRecord, options)
     } catch (err: any) {
-      options.onProgress?.(new CustomProgressEvent<Error>('ipns:routing:dht:error', err))
+      options.onProgress?.(new CustomProgressEvent<Error>('ipns:routing:libp2p:error', err))
     }
   }
 
@@ -31,13 +31,17 @@ export class DHTRouting implements IPNSRouting {
     try {
       return await this.contentRouting.get(routingKey, options)
     } catch (err: any) {
-      options.onProgress?.(new CustomProgressEvent<Error>('ipns:routing:dht:error', err))
+      options.onProgress?.(new CustomProgressEvent<Error>('ipns:routing:libp2p:error', err))
     }
 
     throw new Error('Not found')
   }
 }
 
-export function dht (components: DHTRoutingComponents): IPNSRouting {
-  return new DHTRouting(components)
+/**
+ * The libp2p routing uses any available Content Routers configured on the
+ * passed libp2p node. This could be KadDHT, HTTP API Delegated Routing, etc.
+ */
+export function libp2p (components: Libp2pContentRoutingComponents): IPNSRouting {
+  return new Libp2pContentRouting(components)
 }

--- a/packages/ipns/src/routing/pubsub.ts
+++ b/packages/ipns/src/routing/pubsub.ts
@@ -1,4 +1,4 @@
-import { CodeError } from '@libp2p/interface/errors'
+import { CodeError } from '@libp2p/interface'
 import { logger } from '@libp2p/logger'
 import { peerIdToRoutingKey } from 'ipns'
 import { ipnsSelector } from 'ipns/selector'
@@ -9,8 +9,7 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { localStore, type LocalStore } from './local-store.js'
 import type { GetOptions, IPNSRouting, PutOptions } from './index.js'
-import type { PeerId } from '@libp2p/interface/peer-id'
-import type { Message, PublishResult, PubSub } from '@libp2p/interface/pubsub'
+import type { PeerId, Message, PublishResult, PubSub } from '@libp2p/interface'
 import type { Datastore } from 'interface-datastore'
 
 const log = logger('helia:ipns:routing:pubsub')
@@ -30,14 +29,6 @@ export type PubSubProgressEvents =
   ProgressEvent<'ipns:pubsub:subscribe', { topic: string }> |
   ProgressEvent<'ipns:pubsub:error', Error>
 
-/**
- * This IPNS routing receives IPNS record updates via dedicated
- * pubsub topic.
- *
- * Note we must first be subscribed to the topic in order to receive
- * updated records, so the first call to `.get` should be expected
- * to fail!
- */
 class PubSubRouting implements IPNSRouting {
   private subscriptions: string[]
   private readonly localStore: LocalStore
@@ -192,6 +183,14 @@ function topicToKey (topic: string): Uint8Array {
   return uint8ArrayFromString(key, 'base64url')
 }
 
+/**
+ * This IPNS routing receives IPNS record updates via dedicated
+ * pubsub topic.
+ *
+ * Note we must first be subscribed to the topic in order to receive
+ * updated records, so the first call to `.get` should be expected
+ * to fail!
+ */
 export function pubsub (components: PubsubRoutingComponents): IPNSRouting {
   return new PubSubRouting(components)
 }

--- a/packages/ipns/src/utils/dns.ts
+++ b/packages/ipns/src/utils/dns.ts
@@ -1,4 +1,4 @@
-import { CodeError } from '@libp2p/interface/errors'
+import { CodeError } from '@libp2p/interface'
 import * as isIPFS from 'is-ipfs'
 import type { DNSResolver, ResolveDnsLinkOptions } from '../index.js'
 

--- a/packages/ipns/typedoc.json
+++ b/packages/ipns/typedoc.json
@@ -1,6 +1,7 @@
 {
   "entryPoints": [
     "./src/index.ts",
+    "./src/dns-resolvers/index.ts",
     "./src/routing/index.ts"
   ]
 }


### PR DESCRIPTION
Updates all deps and fixes linting errors.

Renames the `dht` routing to `libp2p` since it's used any and all configured libp2p Content Routers instead of the low-level DHT interface for several releases now.

BREAKING CHANGE: uses multiformats v13 and helia v3, renames `dht` routing to `libp2p`